### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server implementation for ChatterBox, enabling AI agents to interact with online meetings and generate meeting summaries.
 
+<a href="https://glama.ai/mcp/servers/@OverQuotaAI/chatterboxio-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@OverQuotaAI/chatterboxio-mcp-server/badge" alt="ChatterBox Server MCP server" />
+</a>
+
 ## Overview
 
 The ChatterBox MCP Server provides tools for AI agents to:


### PR DESCRIPTION
This PR adds a badge for the [ChatterBox MCP Server](https://glama.ai/mcp/servers/@OverQuotaAI/chatterboxio-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@OverQuotaAI/chatterboxio-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@OverQuotaAI/chatterboxio-mcp-server/badge" alt="ChatterBox Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.